### PR TITLE
fix chrome dash in ubuntu

### DIFF
--- a/chrome-fix/chrome-fix.sh
+++ b/chrome-fix/chrome-fix.sh
@@ -1,0 +1,8 @@
+sudo find ~ -name "*chrome*.desktop"
+#and then after looking at the list and maybe looking inside the files and deciding
+#that you are ok with deleting them just to see if this fixes it....
+sudo find ~ -name "*chrome*.desktop" | xargs rm
+#or something like
+sudo find ~ -name "*chrome*.desktop" | xargs gvfs-trash
+#or maybe just save them in a folder or rename them while you make sure
+#this is the problem


### PR DESCRIPTION
this will fix a chrome dash problem for ubuntu users.
The chrome dash problem happens with selenium script that uses chrome and when you right click the browser that selenium open you will see the add to dash in the menu which destroys the chrome when you try to launch again.